### PR TITLE
refactor: Remove useMemo for options and series in DonutChart component

### DIFF
--- a/src/components/DonutChart/DonutChart.tsx
+++ b/src/components/DonutChart/DonutChart.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useMemo } from "react";
 import Chart from "react-apexcharts";
 import { ApexOptions } from "apexcharts";
 
@@ -13,92 +12,86 @@ interface LegendFormatterOptions {
 }
 
 export const DonutChart = React.memo(() => {
-  const options: ApexOptions = useMemo(
-    () => ({
-      chart: {
-        type: "donut",
-        events: {
-          legendClick: function (chartContext, seriesIndex) {
-            chartContext.toggleDataPointSelection(seriesIndex);
-          },
+  const options: ApexOptions = {
+    chart: {
+      type: "donut",
+      events: {
+        legendClick: function (chartContext, seriesIndex) {
+          chartContext.toggleDataPointSelection(seriesIndex);
         },
       },
-      // title: {
-      //   text: "Top 5 Most Popular Programming Languages 2024",
-      //   style: {
-      //     fontSize: "18px",
-      //     fontWeight: "500",
-      //   },
-      // },
-      labels: ["JavaScript", "Python", "Java", "TypeScript", "C#"],
-      colors: ["#f8c952", "#36A2EB", "#FF6384", "#4BC0C0", "#9966FF"],
-      legend: {
-        position: "bottom",
-        formatter: (seriesName: string, opts: LegendFormatterOptions) => {
-          return `${seriesName}: ${(
-            opts.w.globals.series[opts.seriesIndex] / 1000000
-          ).toLocaleString(undefined, {
+    },
+    // title: {
+    //   text: "Top 5 Most Popular Programming Languages 2024",
+    //   style: {
+    //     fontSize: "18px",
+    //     fontWeight: "500",
+    //   },
+    // },
+    labels: ["JavaScript", "Python", "Java", "TypeScript", "C#"],
+    colors: ["#f8c952", "#36A2EB", "#FF6384", "#4BC0C0", "#9966FF"],
+    legend: {
+      position: "bottom",
+      formatter: (seriesName: string, opts: LegendFormatterOptions) => {
+        return `${seriesName}: ${(
+          opts.w.globals.series[opts.seriesIndex] / 1000000
+        ).toLocaleString(undefined, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })}M`;
+      },
+      onItemClick: {
+        toggleDataSeries: false,
+      },
+    },
+    dataLabels: {
+      enabled: true,
+      formatter: function (_val: number, opts) {
+        return `${(
+          opts.w.globals.series[opts.seriesIndex] / 1000000
+        ).toLocaleString(undefined, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })}M`;
+      },
+      dropShadow: {
+        enabled: false,
+      },
+    },
+    tooltip: {
+      y: {
+        formatter: (value) => {
+          return `${(value / 1000000).toLocaleString(undefined, {
             minimumFractionDigits: 1,
             maximumFractionDigits: 1,
-          })}M`;
-        },
-        onItemClick: {
-          toggleDataSeries: false,
+          })}M developers`;
         },
       },
-      dataLabels: {
-        enabled: true,
-        formatter: function (_val: number, opts) {
-          return `${(
-            opts.w.globals.series[opts.seriesIndex] / 1000000
-          ).toLocaleString(undefined, {
-            minimumFractionDigits: 1,
-            maximumFractionDigits: 1,
-          })}M`;
-        },
-        dropShadow: {
-          enabled: false,
+    },
+    states: {
+      hover: {
+        filter: {
+          type: "none",
         },
       },
-      tooltip: {
-        y: {
-          formatter: (value) => {
-            return `${(value / 1000000).toLocaleString(undefined, {
-              minimumFractionDigits: 1,
-              maximumFractionDigits: 1,
-            })}M developers`;
-          },
+      active: {
+        allowMultipleDataPointsSelection: false,
+        filter: {
+          type: "darken",
         },
       },
-      states: {
-        hover: {
-          filter: {
-            type: "none",
-          },
-        },
-        active: {
-          allowMultipleDataPointsSelection: false,
-          filter: {
-            type: "darken",
-          },
+    },
+    plotOptions: {
+      pie: {
+        expandOnClick: true,
+        donut: {
+          size: "70%",
         },
       },
-      plotOptions: {
-        pie: {
-          expandOnClick: true,
-          donut: {
-            size: "70%",
-          },
-        },
-      },
-    }),
-    []
-  );
+    },
+  };
 
-  const series = useMemo(
-    () => [6700000, 4200000, 2600000, 2300000, 950000],
-    []
-  );
+  const series = [6700000, 4200000, 2600000, 2300000, 950000];
 
   return (
     <div className="donut-chart">


### PR DESCRIPTION
## Description
This PR optimizes the DonutChart component by removing unnecessary `useMemo()` hooks for static configuration objects and data arrays. Since the chart configuration and series data don't depend on any dynamic values or props, the memoization is redundant and adds unnecessary complexity to the code.

## Changes Made
- Converted the memoized `options` configuration object to a simple constant declaration
- Converted the memoized `series` array to a simple constant array
- Removed unused `useMemo` import
- Preserved all functionality with no visual or behavioral changes

## Why This Matters
- Improves code readability by removing unnecessary React hooks
- Follows React best practices for hook usage
- Simplifies future maintenance

fixes #5 

