### PR TITLE
refactor: Remove useMemo from PieChartMonochrome options and series definitions

### DIFF
--- a/src/components/PieChartMonochrome/PieChartMonochrome.tsx
+++ b/src/components/PieChartMonochrome/PieChartMonochrome.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useMemo } from "react";
 import Chart from "react-apexcharts";
 import { ApexOptions } from "apexcharts";
 
@@ -13,82 +12,76 @@ interface LegendFormatterOptions {
 }
 
 export const PieChartMonochrome = React.memo(() => {
-  const options: ApexOptions = useMemo(
-    () => ({
-      chart: {
-        type: "pie",
-        events: {
-          legendClick: function (chartContext, seriesIndex) {
-            chartContext.toggleDataPointSelection(seriesIndex);
-          },
+  const options: ApexOptions = {
+    chart: {
+      type: "pie",
+      events: {
+        legendClick: function (chartContext, seriesIndex) {
+          chartContext.toggleDataPointSelection(seriesIndex);
         },
       },
-      labels: ["United Kingdom", "Germany", "France", "Spain", "Turkey"],
-      colors: ["#172D85", "#1947A3", "#276FD0", "#3497FD", "#72B7FD"],
-      legend: {
-        position: "bottom",
-        formatter: (seriesName: string, opts: LegendFormatterOptions) => {
-          return `${seriesName}: ${(
-            opts.w.globals.series[opts.seriesIndex] / 1000000
-          ).toLocaleString(undefined, {
+    },
+    labels: ["United Kingdom", "Germany", "France", "Spain", "Turkey"],
+    colors: ["#172D85", "#1947A3", "#276FD0", "#3497FD", "#72B7FD"],
+    legend: {
+      position: "bottom",
+      formatter: (seriesName: string, opts: LegendFormatterOptions) => {
+        return `${seriesName}: ${(
+          opts.w.globals.series[opts.seriesIndex] / 1000000
+        ).toLocaleString(undefined, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })}M`;
+      },
+      onItemClick: {
+        toggleDataSeries: false,
+      },
+    },
+    dataLabels: {
+      enabled: true,
+      formatter: function (_val: number, opts) {
+        return `${(
+          opts.w.globals.series[opts.seriesIndex] / 1000000
+        ).toLocaleString(undefined, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })}M`;
+      },
+      dropShadow: {
+        enabled: false,
+      },
+    },
+    tooltip: {
+      y: {
+        formatter: (value) => {
+          return `${(value / 1000000).toLocaleString(undefined, {
             minimumFractionDigits: 1,
             maximumFractionDigits: 1,
-          })}M`;
-        },
-        onItemClick: {
-          toggleDataSeries: false,
+          })}M developers`;
         },
       },
-      dataLabels: {
-        enabled: true,
-        formatter: function (_val: number, opts) {
-          return `${(
-            opts.w.globals.series[opts.seriesIndex] / 1000000
-          ).toLocaleString(undefined, {
-            minimumFractionDigits: 1,
-            maximumFractionDigits: 1,
-          })}M`;
-        },
-        dropShadow: {
-          enabled: false,
+    },
+    states: {
+      hover: {
+        filter: {
+          type: "none",
         },
       },
-      tooltip: {
-        y: {
-          formatter: (value) => {
-            return `${(value / 1000000).toLocaleString(undefined, {
-              minimumFractionDigits: 1,
-              maximumFractionDigits: 1,
-            })}M developers`;
-          },
+      active: {
+        allowMultipleDataPointsSelection: false,
+        filter: {
+          type: "darken",
         },
       },
-      states: {
-        hover: {
-          filter: {
-            type: "none",
-          },
-        },
-        active: {
-          allowMultipleDataPointsSelection: false,
-          filter: {
-            type: "darken",
-          },
-        },
+    },
+    plotOptions: {
+      pie: {
+        expandOnClick: true,
       },
-      plotOptions: {
-        pie: {
-          expandOnClick: true,
-        },
-      },
-    }),
-    []
-  );
+    },
+  };
 
-  const series = useMemo(
-    () => [4000000, 3500000, 2800000, 1800000, 1700000],
-    []
-  );
+  const series = [4000000, 3500000, 2800000, 1800000, 1700000];
 
   return (
     <div className="pie-chart">


### PR DESCRIPTION
## Description
This PR optimizes the PieChartMonochrome component by removing unnecessary useMemo() hooks for static configuration objects and data arrays. Since the chart configuration and series data don't depend on any dynamic values or props, the memoization is redundant and adds unnecessary complexity to the code.

## Changes Made
- Converted the memoized options configuration object to a simple constant declaration
- Converted the memoized series array to a simple constant array
- Removed unused useMemo import
- Preserved all functionality with no visual or behavioral changes

## Why This Matters
- Improves code readability by removing unnecessary React hooks
- Follows React best practices for hook usage
- Simplifies future maintenance

fixes #7 